### PR TITLE
Fix coma error in DscConfigurationData.psd1

### DIFF
--- a/DscConfigurationData/DscConfigurationData.psd1
+++ b/DscConfigurationData/DscConfigurationData.psd1
@@ -43,7 +43,7 @@ Description = 'DSC Tooling'
 # Modules that must be imported into the global environment prior to importing this module
 RequiredModules = @(
     @{ ModuleName = 'ProtectedData'; ModuleVersion = '4.1.0' },
-    ,'powershell-yaml'
+    'powershell-yaml'
 )
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
Removed the coma which prevents the module to be loaded and generates the following error:

The 'RequiredModules' member is not valid in the module manifest file 'C:\Program Files\WindowsPowerShell\Modules\DscConfigurationData\DscConfigurationData.psd1':
Cannot convert the "System.Object[]" value of type "System.Object[]" to type "Microsoft.PowerShell.Commands.ModuleSpecification".